### PR TITLE
Replaced tarsnap with libcrypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.swp
 *.swo
 *~
+.dub/
+scrypt-d

--- a/dub.json
+++ b/dub.json
@@ -7,5 +7,5 @@
     "authors": [
         "Isak Andersson"
     ],
-    "libs-posix": ["tarsnap"]
+    "libs-posix": ["scrypt"]
 }

--- a/source/scrypt/crypto_scrypt.d
+++ b/source/scrypt/crypto_scrypt.d
@@ -46,7 +46,7 @@ extern (C):
  *
  * Return 0 on success; or -1 on error.
  */
-int crypto_scrypt(const uint8_t *, size_t, const uint8_t *, size_t, uint64_t,
+int libscrypt_scrypt(const uint8_t *, size_t, const uint8_t *, size_t, uint64_t,
     uint32_t, uint32_t, uint8_t *, size_t);
 
 

--- a/source/scrypt/crypto_scrypt.d
+++ b/source/scrypt/crypto_scrypt.d
@@ -1,36 +1,5 @@
 module scrypt.crypto_scrypt;
 
-/*-
- * Copyright 2009 Colin Percival
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * This file was originally written by Colin Percival as part of the Tarsnap
- * online backup system.
- * 
- * D binding created by Isak Andersson 2013 (BitPuffin@lavabit.com)
- */
-
 alias ubyte uint8_t;
 alias ulong uint64_t;
 alias uint uint32_t;
@@ -38,7 +7,7 @@ alias uint uint32_t;
 extern (C):
 
 /**
- * crypto_scrypt(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
+ * libscrypt_scrypt(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
  * Compute scrypt(passwd[0 .. passwdlen - 1], salt[0 .. saltlen - 1], N, r,
  * p, buflen) and write the result into buf.  The parameters r, p, and buflen
  * must satisfy r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter N

--- a/source/scrypt/password.d
+++ b/source/scrypt/password.d
@@ -10,7 +10,7 @@ module scrypt.password;
 import scrypt.crypto_scrypt;
 import std.string : indexOf;
 import std.exception : enforce;
-import std.digest.digest : toHexString;
+import std.digest : toHexString;
 import std.uuid : randomUUID;
 import std.algorithm : splitter;
 import std.array: array;
@@ -39,7 +39,7 @@ string genRandomSalt() {
   */
 string genScryptPasswordHash(string password, string salt, size_t scrypt_outputlen, ulong N, uint r, uint p) {
     ubyte[] outpw = new ubyte[scrypt_outputlen];
-    crypto_scrypt(cast(ubyte*)password.ptr, password.length, cast(ubyte*)salt.ptr, salt.length, N, r, p, outpw.ptr, outpw.length);
+    libscrypt_scrypt(cast(ubyte*)password.ptr, password.length, cast(ubyte*)salt.ptr, salt.length, N, r, p, outpw.ptr, outpw.length);
     
     return toHexString(outpw).idup ~ TERMINATOR ~ salt ~ TERMINATOR ~ to!string(scrypt_outputlen) ~ TERMINATOR ~ to!string(N) ~ TERMINATOR ~ to!string(r) ~ TERMINATOR ~ to!string(p);
 }


### PR DESCRIPTION
The project wasn't building so I fixed that. And now it's easier to use since it doesn't require tarsnap libraries but just libscrypt from https://github.com/technion/libscrypt